### PR TITLE
feat(nginx): disables nginx server tokens

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
     server {
         listen 80;
         server_name website-nginx;
+        server_tokens off; # Removes the version from the Server response header
 
         location / {
             proxy_pass http://website-server;


### PR DESCRIPTION
Prevents nginx from returning the nginx version in the "Server" response header.