### PR TITLE
fix(infra): ask ec2 to assign an ipv6 address from the subnet

### DIFF
--- a/internal/infra/ec2.go
+++ b/internal/infra/ec2.go
@@ -44,6 +44,7 @@ func createInstance(
 			InstanceType:             ec2.InstanceType_T2_Micro,
 			SubnetId:                 subnet.ID(),
 			AssociatePublicIpAddress: pulumi.Bool(true),
+			Ipv6AddressCount:         pulumi.Int(1),
 			VpcSecurityGroupIds: pulumi.StringArray{
 				sg.ID(),
 			},


### PR DESCRIPTION
Asks EC2 to assign an IPv6 address from the available addresses from the subnet.

closes #24