### PR TITLE
ci: setup dependabot for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      timezone: Asia/Kolkata
+    assignees:
+      - waduhek
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      timezone: Asia/Kolkata
+    assignees:
+      - waduhek
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      timezone: Asia/Kolkata
+    assignees:
+      - waduhek


### PR DESCRIPTION
Sets up dependabot for upating go modules, docker and github actions.