### PR TITLE
refactor(server): create a new interface for template service

### DIFF
--- a/internal/dependencies.go
+++ b/internal/dependencies.go
@@ -9,7 +9,7 @@ import (
 	experienceRepository "github.com/waduhek/website/internal/experience/repository"
 	"github.com/waduhek/website/internal/logger"
 	projRepo "github.com/waduhek/website/internal/projects/repository"
-	"github.com/waduhek/website/internal/templates"
+	tplsvc "github.com/waduhek/website/internal/templates/service"
 )
 
 // Dependencies is a structure that is used to store all the dependencies that
@@ -20,7 +20,7 @@ type Dependencies struct {
 	ExperienceRepository experienceRepository.ExperienceRepository
 	EducationRepository  eduRepo.EducationRepository
 	ProjectsRepository   projRepo.ProjectsRepository
-	TemplateService      *templates.TemplateService
+	TemplateService      tplsvc.TemplateService
 }
 
 // BuildDependencies builds all the dependencies of the service.
@@ -34,7 +34,7 @@ func BuildDependencies(templateNamePathMap map[string]string) *Dependencies {
 	eduRepo := eduRepo.NewEducationRepository(dbConn, logger)
 	expRepo := experienceRepository.NewExperienceRepository(dbConn, logger)
 	projRepo := projRepo.NewProjectsRepository(dbConn, logger)
-	templateService, err := templates.NewTemplateService(templateNamePathMap)
+	templateService, err := tplsvc.NewTemplateService(templateNamePathMap)
 	if err != nil {
 		logger.Error("error while building template service", "err", err)
 		os.Exit(1)

--- a/internal/education/handler/handler.go
+++ b/internal/education/handler/handler.go
@@ -3,11 +3,11 @@ package handler
 import (
 	"github.com/waduhek/website/internal/education/repository"
 	"github.com/waduhek/website/internal/logger"
-	"github.com/waduhek/website/internal/templates"
+	tplsvc "github.com/waduhek/website/internal/templates/service"
 )
 
 type EducationHandler struct {
 	logger          logger.Logger
 	eduRepo         repository.EducationRepository
-	templateService *templates.TemplateService
+	templateService tplsvc.TemplateService
 }

--- a/internal/experience/handler/handler.go
+++ b/internal/experience/handler/handler.go
@@ -3,11 +3,11 @@ package handlers
 import (
 	"github.com/waduhek/website/internal/experience/repository"
 	"github.com/waduhek/website/internal/logger"
-	"github.com/waduhek/website/internal/templates"
+	tplsvc "github.com/waduhek/website/internal/templates/service"
 )
 
 type ExperienceHandler struct {
 	logger               logger.Logger
 	experienceRepository repository.ExperienceRepository
-	templateService      *templates.TemplateService
+	templateService      tplsvc.TemplateService
 }

--- a/internal/home/handler/handler.go
+++ b/internal/home/handler/handler.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"github.com/waduhek/website/internal/logger"
-	"github.com/waduhek/website/internal/templates"
+	tplsvc "github.com/waduhek/website/internal/templates/service"
 )
 
 type HomeHandler struct {
 	logger          logger.Logger
-	templateService *templates.TemplateService
+	templateService tplsvc.TemplateService
 }

--- a/internal/projects/handler/handler.go
+++ b/internal/projects/handler/handler.go
@@ -3,11 +3,11 @@ package handler
 import (
 	"github.com/waduhek/website/internal/logger"
 	"github.com/waduhek/website/internal/projects/repository"
-	"github.com/waduhek/website/internal/templates"
+	tplsvc "github.com/waduhek/website/internal/templates/service"
 )
 
 type ProjectsHandler struct {
 	logger          logger.Logger
 	projRepo        repository.ProjectsRepository
-	templateService *templates.TemplateService
+	templateService tplsvc.TemplateService
 }

--- a/internal/templates/service/factory.go
+++ b/internal/templates/service/factory.go
@@ -1,0 +1,14 @@
+package tplsvc
+
+import (
+	"github.com/waduhek/website/internal/templates"
+	tplsvcint "github.com/waduhek/website/internal/templates/service/internal"
+)
+
+// NewTemplateService parses all the defined templates and returns a service
+// for interacting with the templates.
+func NewTemplateService(
+	templateNameFileMap map[templates.TemplateName]string,
+) (TemplateService, error) {
+	return tplsvcint.NewTemplateServiceImpl(templateNameFileMap)
+}

--- a/internal/templates/service/interface.go
+++ b/internal/templates/service/interface.go
@@ -1,0 +1,13 @@
+package tplsvc
+
+import (
+	"html/template"
+
+	"github.com/waduhek/website/internal/templates"
+)
+
+type TemplateService interface {
+	// GetTemplate gets the template by the provided name. Returns nil if the
+	// template was not found.
+	GetTemplate(name templates.TemplateName) *template.Template
+}

--- a/internal/templates/service/internal/get_template.go
+++ b/internal/templates/service/internal/get_template.go
@@ -1,0 +1,14 @@
+package tplsvcint
+
+import (
+	"html/template"
+
+	"github.com/waduhek/website/internal/templates"
+)
+
+func (t *TemplateServiceImpl) GetTemplate(
+	name templates.TemplateName,
+) *template.Template {
+	mappedName := t.templateNameMapper[name]
+	return t.templateBox.Lookup(mappedName)
+}

--- a/internal/templates/service/internal/get_template_test.go
+++ b/internal/templates/service/internal/get_template_test.go
@@ -1,4 +1,4 @@
-package templates_test
+package tplsvcint_test
 
 import (
 	"fmt"
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/waduhek/website/internal/templates"
+	tplsvc "github.com/waduhek/website/internal/templates/service"
+	tplsvcint "github.com/waduhek/website/internal/templates/service/internal"
 )
 
 const templateFileName string = "temp-template.txt.tmpl"
@@ -33,7 +35,7 @@ func TestTemplateParseError(t *testing.T) {
 	tempDir := t.TempDir()
 	nonExistentTemplate := path.Join(tempDir, templateFileName)
 
-	_, err := templates.NewTemplateService(map[templates.TemplateName]string{
+	_, err := tplsvc.NewTemplateService(map[templates.TemplateName]string{
 		templates.Home: nonExistentTemplate,
 	})
 	if err == nil {
@@ -41,7 +43,7 @@ func TestTemplateParseError(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T) *templates.TemplateService {
+func setup(t *testing.T) *tplsvcint.TemplateServiceImpl {
 	tempDir := t.TempDir()
 	pathToTemplate := path.Join(tempDir, templateFileName)
 
@@ -52,7 +54,7 @@ func setup(t *testing.T) *templates.TemplateService {
 
 	fmt.Fprint(file, "{{.Text}}")
 
-	templateService, err := templates.NewTemplateService(
+	templateService, err := tplsvcint.NewTemplateServiceImpl(
 		map[templates.TemplateName]string{
 			templates.Home: pathToTemplate,
 		},

--- a/internal/templates/service/internal/new_service.go
+++ b/internal/templates/service/internal/new_service.go
@@ -1,0 +1,33 @@
+package tplsvcint
+
+import (
+	"html/template"
+	"path/filepath"
+
+	"github.com/waduhek/website/internal/templates"
+)
+
+func NewTemplateServiceImpl(
+	templateNameFileMap map[templates.TemplateName]string,
+) (*TemplateServiceImpl, error) {
+	templateBox := template.New("box")
+	templateNameMapper := make(map[templates.TemplateName]string)
+
+	for nameType, templatePath := range templateNameFileMap {
+		_, err := templateBox.ParseFiles(templatePath)
+		if err != nil {
+			return nil, err
+		}
+
+		// This is the actual name of the template that is stored.
+		fileName := filepath.Base(templatePath)
+		// This mapping is required since `template.ParseFiles` names the
+		// templates as the file name. I require something that allows me to
+		// dynamically parse templates and associate them with some fixed string
+		// so that there won't be magic strings where ever the templates are
+		// being executed.
+		templateNameMapper[nameType] = fileName
+	}
+
+	return &TemplateServiceImpl{templateBox, templateNameMapper}, nil
+}

--- a/internal/templates/service/internal/service_impl.go
+++ b/internal/templates/service/internal/service_impl.go
@@ -1,0 +1,12 @@
+package tplsvcint
+
+import (
+	"html/template"
+
+	"github.com/waduhek/website/internal/templates"
+)
+
+type TemplateServiceImpl struct {
+	templateBox        *template.Template
+	templateNameMapper map[templates.TemplateName]string
+}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,10 +1,5 @@
 package templates
 
-import (
-	"html/template"
-	"path/filepath"
-)
-
 type TemplateName = string
 
 const (
@@ -15,43 +10,3 @@ const (
 	Education  TemplateName = "education"  // Education is the template for education section.
 	Projects   TemplateName = "projects"   // Projects is the template for projects section.
 )
-
-// TemplateService is a storage container for all the templates registered.
-type TemplateService struct {
-	templateBox        *template.Template
-	templateNameMapper map[TemplateName]string
-}
-
-// GetTemplate gets the template by the provided name. Returns nil if the
-// template was not found.
-func (t *TemplateService) GetTemplate(name TemplateName) *template.Template {
-	mappedName := t.templateNameMapper[name]
-	return t.templateBox.Lookup(mappedName)
-}
-
-// NewTemplateService parses all the defined templates and returns a service
-// for interacting with the templates.
-func NewTemplateService(
-	templateNameFileMap map[TemplateName]string,
-) (*TemplateService, error) {
-	templateBox := template.New("box")
-	templateNameMapper := make(map[TemplateName]string)
-
-	for nameType, templatePath := range templateNameFileMap {
-		_, err := templateBox.ParseFiles(templatePath)
-		if err != nil {
-			return nil, err
-		}
-
-		// This is the actual name of the template that is stored.
-		fileName := filepath.Base(templatePath)
-		// This mapping is required since `template.ParseFiles` names the
-		// templates as the file name. I require something that allows me to
-		// dynamically parse templates and associate them with some fixed string
-		// so that there won't be magic strings where ever the templates are
-		// being executed.
-		templateNameMapper[nameType] = fileName
-	}
-
-	return &TemplateService{templateBox, templateNameMapper}, nil
-}


### PR DESCRIPTION
Creates a new interface for template service and uses the interface instead of the struct as the dependency in handlers.