### PR TITLE
fix(nginx): disables ssl stapling and server ciphers

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -51,8 +51,6 @@ http {
         ssl_certificate_key
             /etc/letsencrypt/live/www.ryannoronha.com/privkey.pem;
 
-        ssl_stapling on;
-        ssl_stapling_verify on;
         ssl_trusted_certificate
             /etc/letsencrypt/live/www.ryannoronha.com/chain.pem;
 
@@ -61,8 +59,6 @@ http {
         ssl_session_tickets off;
 
         ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_prefer_server_ciphers on;
-
         ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
         ssl_ecdh_curve secp384r1;
 


### PR DESCRIPTION
* Disables OCSP stapling since LetsEncrypt does not currently support stapling.
* Disables server cipher preference.