### PR TITLE
fix(nginx): add sts header to https server block

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -62,6 +62,9 @@ http {
         ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
         ssl_ecdh_curve secp384r1;
 
+        add_header Strict-Transport-Security
+            "max-age=31536000; includeSubDomains" always;
+
         location / {
             proxy_pass http://website-server;
         }


### PR DESCRIPTION
Adds Strict-Transport-Security header to the HTTPS server block.