### PR TITLE
fix(nginx): adds headers recommended by owasp

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -63,7 +63,16 @@ http {
         ssl_ecdh_curve secp384r1;
 
         add_header Strict-Transport-Security
-            "max-age=31536000; includeSubDomains" always;
+            "max-age=31536000; includeSubDomains; preload" always;
+        add_header Content-Security-Policy "default-src 'self'" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options DENY always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cross-Origin-Opener-Policy same-origin always;
+        add_header Cross-Origin-Embedder-Policy require-corp always;
+        add_header Cross-Origin-Resource-Policy same-site always;
+        add_header Permissions-Policy "geolocation=(), camera=(), microphone=()"
+            always;
 
         location / {
             proxy_pass http://website-server;


### PR DESCRIPTION
Adds the headers Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Embedder-Policy, Cross-Origin-Resource-Policy, and Permissions-Policy headers to the response of all paths.