### PR TITLE
ci: update dependabot config to include nginx docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
       - waduhek
 
   - package-ecosystem: docker
-    directory: /
+    directories:
+      - "/"
+      - "/nginx"
     schedule:
       interval: weekly
       timezone: Asia/Kolkata


### PR DESCRIPTION
Updates dependabot configuration to update nginx docker image on a weekly basis.