### PR TITLE
feat(infra): add cloudwatch log group and attach role to ec2

### DIFF
--- a/cmd/infra/main.go
+++ b/cmd/infra/main.go
@@ -18,10 +18,23 @@ func main() {
 			return err
 		}
 
+		logGroup, err := infra.CreateLogGroup(ctx)
+		if err != nil {
+			return err
+		}
+
+		ec2InstProfile, err := infra.CreateWebsiteEC2InstanceProfile(
+			ctx, logGroup,
+		)
+		if err != nil {
+			return err
+		}
+
 		websiteInstance, err := infra.CreateEC2Instance(
 			ctx,
 			websitePublicSubnet,
 			websiteSG,
+			ec2InstProfile,
 		)
 		if err != nil {
 			return err

--- a/internal/infra/ec2.go
+++ b/internal/infra/ec2.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -10,13 +11,14 @@ func CreateEC2Instance(
 	ctx *pulumi.Context,
 	subnet *ec2.Subnet,
 	sg *ec2.SecurityGroup,
+	instProfile *iam.InstanceProfile,
 ) (*ec2.Instance, error) {
 	ec2KeyPair, err := createKeyPair(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return createInstance(ctx, subnet, sg, ec2KeyPair)
+	return createInstance(ctx, subnet, sg, ec2KeyPair, instProfile)
 }
 
 func createKeyPair(ctx *pulumi.Context) (*ec2.KeyPair, error) {
@@ -35,6 +37,7 @@ func createInstance(
 	subnet *ec2.Subnet,
 	sg *ec2.SecurityGroup,
 	keyPair *ec2.KeyPair,
+	instProf *iam.InstanceProfile,
 ) (*ec2.Instance, error) {
 	return ec2.NewInstance(
 		ctx,
@@ -57,7 +60,8 @@ sudo systemctl enable docker
 sudo usermod -aG docker $USER
 newgrp docker
 				`),
-			KeyName: keyPair.KeyName,
+			KeyName:            keyPair.KeyName,
+			IamInstanceProfile: instProf.Name,
 		},
 	)
 }

--- a/internal/infra/iam.go
+++ b/internal/infra/iam.go
@@ -1,0 +1,98 @@
+package infra
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudwatch"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// CreateWebsiteEC2InstanceProfile creates the policy, role, and instance
+// profile for the EC2 instance.
+func CreateWebsiteEC2InstanceProfile(
+	ctx *pulumi.Context,
+	logGroup *cloudwatch.LogGroup,
+) (*iam.InstanceProfile, error) {
+	policyDocOutput := createIAMPolicyDoc(ctx, logGroup)
+
+	role, err := createIAMRole(ctx, policyDocOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	return createInstanceProfile(ctx, role)
+}
+
+func createIAMPolicyDoc(
+	ctx *pulumi.Context,
+	l *cloudwatch.LogGroup,
+) pulumi.Output {
+	return l.Arn.ApplyT(func(arn string) (string, error) {
+		policyDoc, err := iam.GetPolicyDocument(
+			ctx,
+			&iam.GetPolicyDocumentArgs{
+				Statements: []iam.GetPolicyDocumentStatement{
+					{
+						Effect: pulumi.StringRef("Allow"),
+						Actions: []string{
+							"logs:PutLogEvents",
+							"logs:DescribeLogGroups",
+							"logs:DescribeLogStreams",
+						},
+						Resources: []string{
+							fmt.Sprintf("%s:*", arn),
+						},
+					},
+					{
+						Effect: pulumi.StringRef("Allow"),
+						Actions: []string{
+							"xray:PutTraceSegments",
+							"xray:PutTelemetryRecords",
+							"xray:GetSamplingRules",
+							"xray:GetSamplingTargets",
+							"xray:GetSamplingStatisticSummaries",
+						},
+						Resources: []string{
+							"*",
+						},
+					},
+				},
+			},
+		)
+
+		if err != nil {
+			return "", err
+		}
+
+		return policyDoc.Json, nil
+	})
+}
+
+func createIAMRole(
+	ctx *pulumi.Context,
+	policyOutput pulumi.Output,
+) (*iam.Role, error) {
+	return iam.NewRole(
+		ctx,
+		"website-ec2-role",
+		&iam.RoleArgs{
+			Description:      pulumi.String("Website instance role"),
+			AssumeRolePolicy: policyOutput,
+		},
+	)
+}
+
+func createInstanceProfile(
+	ctx *pulumi.Context,
+	role *iam.Role,
+) (*iam.InstanceProfile, error) {
+	return iam.NewInstanceProfile(
+		ctx,
+		"website-ec2-role",
+		&iam.InstanceProfileArgs{
+			Name: pulumi.String("website-ec2-role"),
+			Role: role.Name,
+		},
+	)
+}

--- a/internal/infra/monitoring.go
+++ b/internal/infra/monitoring.go
@@ -1,0 +1,34 @@
+package infra
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudwatch"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// CreateLogGroup creates the log group and log stream for uploading logs.
+func CreateLogGroup(ctx *pulumi.Context) (*cloudwatch.LogGroup, error) {
+	logGroup, err := cloudwatch.NewLogGroup(
+		ctx,
+		"website-logs",
+		&cloudwatch.LogGroupArgs{
+			Name: pulumi.String("website-logs"),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = cloudwatch.NewLogStream(
+		ctx,
+		"website-logs-stream",
+		&cloudwatch.LogStreamArgs{
+			Name:         pulumi.String("website-logs-stream"),
+			LogGroupName: logGroup.Name,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return logGroup, nil
+}


### PR DESCRIPTION
* Creates a CloudWatch log group and log stream to upload application signals.
* Attaches an IAM role to the EC2 instance to allow the signals to be uploaded.

closes #76