### PR TITLE
fix(infra): set correct arn for cloudwatch logs policy

### DIFF
--- a/internal/infra/iam.go
+++ b/internal/infra/iam.go
@@ -1,8 +1,6 @@
 package infra
 
 import (
-	"fmt"
-
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudwatch"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -41,7 +39,7 @@ func createIAMPolicyDoc(
 							"logs:DescribeLogStreams",
 						},
 						Resources: []string{
-							fmt.Sprintf("%s:*", arn),
+							arn,
 						},
 					},
 					{


### PR DESCRIPTION
Removes the extra `*` at the end of the ARN for the CloudWatch log group.

closes #76