### PR TITLE
fix(infra): add all log streams to the ec2 iam policy

### DIFF
--- a/internal/infra/iam.go
+++ b/internal/infra/iam.go
@@ -1,6 +1,8 @@
 package infra
 
 import (
+	"fmt"
+
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudwatch"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -74,7 +76,7 @@ func createIAMPolicyDoc(
 							"logs:DescribeLogStreams",
 						},
 						Resources: []string{
-							arn,
+							fmt.Sprintf("%s:*:*", arn),
 						},
 					},
 					{


### PR DESCRIPTION
Allow write access to EC2 instance to all log streams in the website log group.