### PR TITLE
fix(otelcol): set a name for the metrics namespace

### DIFF
--- a/otelcol/collector-config.yaml
+++ b/otelcol/collector-config.yaml
@@ -25,6 +25,7 @@ exporters:
     region: ap-south-1
     log_group_name: website-logs
     log_stream_name: website-logs-stream
+    namespace: Website
 
   awscloudwatchlogs:
     region: ap-south-1


### PR DESCRIPTION
Sets a name for the CloudWatch metrics namespace instead of the default value.