### PR TITLE
feat(server): export global metrics recommended in otel conventions

### DIFF
--- a/cmd/website/main.go
+++ b/cmd/website/main.go
@@ -31,6 +31,15 @@ func main() {
 
 	dependencies := internal.BuildDependencies(internal.TemplateNameFileMap)
 
+	metricsCollector, err := telemetry.NewTelemetryCollector(dependencies.Meter)
+	if err != nil {
+		slog.Error(
+			"error while initialising global metrics collector",
+			"error", err,
+		)
+		os.Exit(1)
+	}
+
 	mux := http.NewServeMux()
 
 	mux.Handle(
@@ -62,7 +71,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:    ":8080",
-		Handler: mux,
+		Handler: metricsCollector.CollectDefaultMetricsMiddleware(mux),
 	}
 
 	go server.ListenAndServe()

--- a/internal/telemetry/internal/runtime.go
+++ b/internal/telemetry/internal/runtime.go
@@ -1,0 +1,229 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"runtime/metrics"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/semconv/v1.37.0/goconv"
+)
+
+// RegisterMemoryUsedMetric registers the metric for getting process memory
+// utilisation.
+func RegisterMemoryUsedMetric(meter metric.Meter) error {
+	_, err := goconv.NewMemoryUsed(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				memoryTotalMetric := "/memory/classes/total:bytes"
+				memoryReleasedMetric := "/memory/classes/heap/released:bytes"
+
+				sample := make([]metrics.Sample, 2)
+
+				sample[0].Name = memoryTotalMetric
+				sample[1].Name = memoryReleasedMetric
+
+				metrics.Read(sample)
+
+				for _, s := range sample {
+					if s.Value.Kind() == metrics.KindBad {
+						return fmt.Errorf("bad sample metric: %s", s.Name)
+					}
+				}
+
+				memoryTotal := sample[0].Value.Uint64()
+				memoryReleased := sample[1].Value.Uint64()
+
+				io.Observe(int64(memoryTotal - memoryReleased))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// RegisterMemoryLimitMetric registers the metric for collecting memory limit
+// from the Go runtime.
+func RegisterMemoryLimitMetric(meter metric.Meter) error {
+	_, err := goconv.NewMemoryLimit(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				memLimitMetric := "/gc/gomemlimit:bytes"
+
+				memLimit, err := readSingleMetricUint(memLimitMetric)
+				if err != nil {
+					return err
+				}
+
+				io.Observe(int64(memLimit))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// RegisterMemoryAllocatedMetric registers the metric to collect memory
+// allocations made to the process.
+func RegisterMemoryAllocatedMetric(meter metric.Meter) error {
+	_, err := goconv.NewMemoryAllocated(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				memAllocMetric := "/gc/heap/allocs:bytes"
+
+				memAlloc, err := readSingleMetricUint(memAllocMetric)
+				if err != nil {
+					return err
+				}
+
+				io.Observe(int64(memAlloc))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// RegisterMemoryAllocationsMetric registers the metric to count the number of
+// memory allocations made to the process.
+func RegisterMemoryAllocationsMetric(meter metric.Meter) error {
+	_, err := goconv.NewMemoryAllocations(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				memAllocsMetric := "/gc/heap/allocs:objects"
+
+				memAllocs, err := readSingleMetricUint(memAllocsMetric)
+				if err != nil {
+					return err
+				}
+
+				io.Observe(int64(memAllocs))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// RegisterGCGoalMetric registers the metric for measuring the GC goal.
+func RegisterGCGoalMetric(meter metric.Meter) error {
+	_, err := goconv.NewMemoryGCGoal(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				gcGoalMetric := "/gc/heap/goal:bytes"
+
+				gcGoal, err := readSingleMetricUint(gcGoalMetric)
+				if err != nil {
+					return err
+				}
+
+				io.Observe(int64(gcGoal))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// RegisterGoRoutineCountMetric registers the metric to report the number of
+// goroutines.
+func RegisterGoRoutineCountMetric(meter metric.Meter) error {
+	_, err := goconv.NewGoroutineCount(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				goRoutineMetric := "/sched/goroutines:goroutines"
+
+				goRoutine, err := readSingleMetricUint(goRoutineMetric)
+				if err != nil {
+					return err
+				}
+
+				io.Observe(int64(goRoutine))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// RegisterProcessorLimitMetric registers the metric to report the maximum
+// number of OS threads that can be spawned.
+func RegisterProcessorLimitMetric(meter metric.Meter) error {
+	_, err := goconv.NewProcessorLimit(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				processorLimitMetric := "/sched/gomaxprocs:threads"
+
+				processorLimit, err := readSingleMetricUint(
+					processorLimitMetric,
+				)
+				if err != nil {
+					return err
+				}
+
+				io.Observe(int64(processorLimit))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// RegisterGoGCConfigMetric exports the heap size target metric.
+func RegisterGoGCConfigMetric(meter metric.Meter) error {
+	_, err := goconv.NewConfigGogc(
+		meter,
+		metric.WithInt64Callback(
+			func(ctx context.Context, io metric.Int64Observer) error {
+				goGCConfigMetric := "/gc/gogc:percent"
+
+				goGCConfig, err := readSingleMetricUint(goGCConfigMetric)
+				if err != nil {
+					return nil
+				}
+
+				io.Observe(int64(goGCConfig))
+
+				return nil
+			},
+		),
+	)
+
+	return err
+}
+
+// readSingleMetricUint reads the metric with the provided name and returns its
+// value as a uint64 type.
+func readSingleMetricUint(name string) (uint64, error) {
+	sample := make([]metrics.Sample, 1)
+	sample[0].Name = name
+
+	metrics.Read(sample)
+
+	if sample[0].Value.Kind() == metrics.KindBad {
+		return 0, fmt.Errorf("bad sample metric: %s", name)
+	}
+
+	return sample[0].Value.Uint64(), nil
+}

--- a/internal/telemetry/middlewares.go
+++ b/internal/telemetry/middlewares.go
@@ -1,0 +1,105 @@
+package telemetry
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/waduhek/website/internal/telemetry/internal"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"go.opentelemetry.io/otel/semconv/v1.37.0/httpconv"
+)
+
+type TelemetryCollector struct {
+	activeRequestsMeter  httpconv.ServerActiveRequests
+	requestDurationMeter httpconv.ServerRequestDuration
+}
+
+// NewTelemetryCollector creates a new instance of the telemetry collector.
+func NewTelemetryCollector(
+	meter metric.Meter,
+) (*TelemetryCollector, error) {
+	activeRequestsMeter, err := httpconv.NewServerActiveRequests(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	requestDurationMeter, err := httpconv.NewServerRequestDuration(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	// Go runtime metrics. These are all observable meters and so are not saved
+	// to the the struct's fields.
+
+	err = internal.RegisterMemoryUsedMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = internal.RegisterMemoryLimitMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = internal.RegisterMemoryAllocatedMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = internal.RegisterMemoryAllocationsMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = internal.RegisterGCGoalMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = internal.RegisterGoRoutineCountMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = internal.RegisterProcessorLimitMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = internal.RegisterGoGCConfigMetric(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TelemetryCollector{activeRequestsMeter, requestDurationMeter}, nil
+}
+
+// CollectDefaultMetricsMiddleware is a middleware function that collects all
+// the default metrics for the HTTP server.
+func (c *TelemetryCollector) CollectDefaultMetricsMiddleware(
+	next http.Handler,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		method := httpconv.RequestMethodAttr(r.Method)
+		scheme := r.URL.Scheme
+		route := r.URL.Path
+		routeAttribute := semconv.HTTPRoute(route)
+
+		c.activeRequestsMeter.Add(ctx, 1, method, scheme, routeAttribute)
+
+		start := time.Now()
+
+		// Perform the request.
+		next.ServeHTTP(w, r)
+
+		requestDuration := time.Since(start).Seconds()
+
+		c.activeRequestsMeter.Add(ctx, -1, method, scheme)
+		c.requestDurationMeter.Record(
+			ctx, requestDuration, method, scheme,
+			routeAttribute,
+		)
+	})
+}


### PR DESCRIPTION
Exports (almost) all metrics recommended by the OTel semantic conventions.

closes #71