### PR TITLE
fix(server): set route attribute when reducing the active requests meter

### DIFF
--- a/internal/telemetry/middlewares.go
+++ b/internal/telemetry/middlewares.go
@@ -96,7 +96,7 @@ func (c *TelemetryCollector) CollectDefaultMetricsMiddleware(
 
 		requestDuration := time.Since(start).Seconds()
 
-		c.activeRequestsMeter.Add(ctx, -1, method, scheme)
+		c.activeRequestsMeter.Add(ctx, -1, method, scheme, routeAttribute)
 		c.requestDurationMeter.Record(
 			ctx, requestDuration, method, scheme,
 			routeAttribute,


### PR DESCRIPTION
Sets the route attribute when decrementing the count of active HTTP requests allowing the value to be decremented correctly.