### PR TITLE
fix(server): create correct cache mount in server dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.25.4 AS builder
 WORKDIR /app
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/gobuild \
+RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o ./build/website ./cmd/website
 
 FROM scratch AS runner


### PR DESCRIPTION
Fixes a typo in the path to the cache mount.