### PR TITLE
fix(otelcol): reduce batcher frequency to 60s from 30s

### DIFF
--- a/otelcol/collector-config.yaml
+++ b/otelcol/collector-config.yaml
@@ -39,7 +39,7 @@ processors:
     spike_limit_mib: 500
 
   batch:
-    timeout: 30s
+    timeout: 60s
 
   probabilistic_sampler:
     sampling_percentage: 10


### PR DESCRIPTION
Reduces the frequency at which the batcher exports signals to 60s from 30s.