### PR TITLE
refactor(server): add deployment environment name to otel resource

### DIFF
--- a/internal/telemetry/setup.go
+++ b/internal/telemetry/setup.go
@@ -181,11 +181,17 @@ func getOTLPEndpoint() (string, error) {
 }
 
 func newResource() (*resource.Resource, error) {
+	deploymentEnv := os.Getenv("DEPLOYMENT_ENVIRONMENT")
+	if deploymentEnv == "" {
+		deploymentEnv = "local"
+	}
+
 	return resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("website-backend"),
+			semconv.ServiceName("website-backend"),
+			semconv.DeploymentEnvironmentName(deploymentEnv),
 		),
 	)
 }

--- a/sample.env
+++ b/sample.env
@@ -1,1 +1,8 @@
+# Deployment environment of the application. The value of this variable is used
+# to create the resource for Opentelemetry. Defaults to local if not set.
+DEPLOYMENT_ENVIRONMENT=local
+
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/website
+
+# Endpoint to the OTel Collector.
+OTLP_ENDPOINT=


### PR DESCRIPTION
Adds deployment environment name to the OTel resource created at the time of setting up the SDK.