### PR TITLE
refactor(nginx): remove all custom span attributes set in config

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,13 +25,6 @@ http {
     map $request_uri $request_uri_path {
       "~^(?P<path>[^?]*)(\?.*)?$"  $path;
     }
-    map $server_protocol $protocol_version {
-        "HTTP/1.0" "1.0";
-        "HTTP/1.1" "1.1";
-        "HTTP/2.0" "2.0";
-        "HTTP/3.0" "3.0";
-        default $server_protocol;
-    }
 
     # OTel config
     otel_trace on;
@@ -41,18 +34,6 @@ http {
     otel_service_name website-nginx;
     otel_trace_context propagate;
     otel_span_name "$request_method $request_uri_path";
-    # Set some span attributes. See issue #120 for more details.
-    otel_span_attr http.request.method $request_method;
-    otel_span_attr url.path $request_uri_path;
-    otel_span_attr url.scheme $scheme;
-    otel_span_attr network.protocol.version $protocol_version;
-    otel_span_attr user_agent.original $http_user_agent;
-    otel_span_attr http.request.body.size $content_length;
-    otel_span_attr http.response.body.size $upstream_response_length;
-    otel_span_attr http.response.status_code $status;
-    otel_span_attr server.address $hostname;
-    otel_span_attr network.peer.address $remote_addr;
-    otel_span_attr network.peer.port $remote_port;
 
     upstream website-server {
         server website-server:8080;


### PR DESCRIPTION
Removes all custom span attributes set in the config file. The updated span attributes will be set by the container.

see #120