### PR TITLE
fix(server): update the buckets for http request duration metric

### DIFF
--- a/internal/telemetry/middlewares.go
+++ b/internal/telemetry/middlewares.go
@@ -18,7 +18,13 @@ type TelemetryCollector struct {
 func NewTelemetryCollector(
 	meter metric.Meter,
 ) (*TelemetryCollector, error) {
-	requestDurationMeter, err := httpconv.NewServerRequestDuration(meter)
+	requestDurationMeter, err := httpconv.NewServerRequestDuration(
+		meter,
+		metric.WithExplicitBucketBoundaries(
+			0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5,
+			7.5, 10,
+		),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates the buckets used for HTTP request duration metrics to the buckets recommended by OTel semantic conventions.