### PR TITLE
feat(otelcol): add filter processor to remove metric data points

### DIFF
--- a/otelcol/builder-config.yaml
+++ b/otelcol/builder-config.yaml
@@ -15,6 +15,8 @@ processors:
       github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.141.0
   - gomod:
       github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.141.0
+  - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.141.0
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.141.0

--- a/otelcol/collector-config.yaml
+++ b/otelcol/collector-config.yaml
@@ -80,6 +80,14 @@ processors:
           - set(attributes["deployment.environment.name"], resource.attributes["deployment.environment.name"])
           - set(attributes["service.version"], resource.attributes["service.version"])
 
+  filter:
+    error_mode: ignore
+    metrics:
+      datapoint:
+        # Filter out http.server.request.duration data points that are not GET
+        # method type.
+        - metric.name == "http.server.request.duration" and resource.attributes["http.request.method"] != "GET"
+
 connectors:
   grafanacloud:
     host_identifiers:
@@ -110,6 +118,7 @@ service:
         - otlp
       processors:
         - memory_limiter
+        - filter
         - resourcedetection
         - transform/drop_unneeded_resource_attributes
         - transform/add_resource_attributes_as_metric_attributes


### PR DESCRIPTION
Adds filter processor to remove metric data-points of `http.server.request.duration` metric that are not of the GET request method.