### PR TITLE
feat(otelcol): disable docker resource detector in collector config

### DIFF
--- a/otelcol/collector-config.yaml
+++ b/otelcol/collector-config.yaml
@@ -30,7 +30,6 @@ processors:
   resourcedetection:
     detectors:
       - env
-      - docker
       - ec2
 
   transform/drop_unneeded_resource_attributes:


### PR DESCRIPTION
Disables docker resource detector since it doesn't set any resource attributes.