### PR TITLE
fix(otelcol): correctly check metric attribute for filter processor

### DIFF
--- a/otelcol/builder-config.yaml
+++ b/otelcol/builder-config.yaml
@@ -2,7 +2,7 @@ dist:
   name: website-otelcol
   description: OTel collector for collecting signals from the the application service and DB instances and exporting them to AWS.
   output_path: ./build
-  version: 0.5.0
+  version: 0.5.1
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.142.0

--- a/otelcol/collector-config.yaml
+++ b/otelcol/collector-config.yaml
@@ -85,7 +85,7 @@ processors:
       datapoint:
         # Filter out http.server.request.duration data points that are not GET
         # method type.
-        - metric.name == "http.server.request.duration" and resource.attributes["http.request.method"] != "GET"
+        - metric.name == "http.server.request.duration" and metric.attributes["http.request.method"] != "GET"
 
 connectors:
   grafanacloud:


### PR DESCRIPTION
Check metric attributes instead of resource attribute when filtering metric data-points.