### PR TITLE
feat(server): removes metrics from `/static` route handlers

### DIFF
--- a/cmd/website/main.go
+++ b/cmd/website/main.go
@@ -44,20 +44,16 @@ func main() {
 
 	mux.Handle(
 		"GET /static/css/",
-		metricsCollector.CollectDefaultMetricsMiddleware(
-			http.StripPrefix(
-				"/static/css/",
-				http.FileServer(http.Dir("static/css")),
-			),
+		http.StripPrefix(
+			"/static/css/",
+			http.FileServer(http.Dir("static/css")),
 		),
 	)
 	mux.Handle(
 		"GET /static/js/",
-		metricsCollector.CollectDefaultMetricsMiddleware(
-			http.StripPrefix(
-				"/static/js/",
-				http.FileServer(http.Dir("static/js")),
-			),
+		http.StripPrefix(
+			"/static/js/",
+			http.FileServer(http.Dir("static/js")),
 		),
 	)
 


### PR DESCRIPTION
Removes metrics from the handlers of `/static` routes which are `GET /static/js` and `GET /static/css`.

closes #139